### PR TITLE
Update for react-native 0.43+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-native-workers (RN 0.41^)
+# react-native-workers (RN 0.43^)
 Do heavy data process outside of your UI JS thread.
 
 Before using this kind of solution you should check if [InteractionManager.runAfterInteractions](https://facebook.github.io/react-native/docs/interactionmanager.html) is not enough for your needs, because creating a aditional worker can considerably increase app memory usage. 

--- a/SETUP.md
+++ b/SETUP.md
@@ -39,7 +39,7 @@
             super.onCreate();
             SoLoader.init(this, /* native exopackage */ false);
             //Initialize Manager instance
-            RNWorkersManager.init(this, BuildConfig.DEBUG);
+            RNWorkersManager.getInstance().init(this, BuildConfig.DEBUG);
         }
     }
 ```
@@ -52,7 +52,7 @@
       @Override
       protected void onCreate(Bundle savedInstanceState) {       
         //CRITICAL: Must be started before super.onCreate to be possible to debug on chrome console
-        RNWorkersManager.start(getMainComponentName());
+        RNWorkersManager.getInstance().startWorkers();
         super.onCreate(savedInstanceState);
       }
   }

--- a/android/src/main/java/com/fabricio/vergal/RNWorkers/RNWorkersUtils.java
+++ b/android/src/main/java/com/fabricio/vergal/RNWorkers/RNWorkersUtils.java
@@ -5,7 +5,7 @@ import android.content.SharedPreferences;
 
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
-import com.facebook.react.modules.debug.DeveloperSettings;
+import com.facebook.react.modules.debug.interfaces.DeveloperSettings;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;


### PR DESCRIPTION
Some refactorings in `react-native` breaks the workers as interfaces were moved in 0.43 (and the current stable 0.44).

Also updated the setup instructions to match the sample code (the code was right; the setup instructions were wrong/obsolete).