### PR TITLE
Fix conversion of NSNumber to NSString

### DIFF
--- a/ios/RNWorkers/RNWorkersManager.m
+++ b/ios/RNWorkers/RNWorkersManager.m
@@ -51,8 +51,8 @@
             [NSException raise:@"rn-worker" format:@"JS bundle '%@.jsbundle' not found", resource];
         }
     }else{
-        NSString *workerPort = [NSString stringWithFormat:@"%d", nsPort];
-        NSString *appPort = [NSString stringWithFormat:@"%d", jsCodeLocation.port];
+        NSString *workerPort = [nsPort stringValue];
+        NSString *appPort = [jsCodeLocation.port stringValue];
         NSString *path = [jsCodeLocation.absoluteString stringByReplacingOccurrencesOfString:appPort withString:workerPort];
         jsCodeLocation = [[NSURL alloc] initWithString:path];
     }


### PR DESCRIPTION
This patch fixes an issue in the code where packager ports where mistakenly converted to `NSString` from `int` instead of `NSNumber` (or more generally `NSObject`).

This had the side effect of fixing several init issues in my case.